### PR TITLE
Create slackWebhook.js

### DIFF
--- a/slackWebhook.js
+++ b/slackWebhook.js
@@ -1,0 +1,20 @@
+const axios = require('axios');
+
+// Replace with your Slack webhook URL
+const slackWebhookUrl = 'https://hooks.slack.com/services/YOUR/WEBHOOK/URL';
+
+// Create a function to send a message to Slack
+async function sendSlackMessage(message) {
+    try {
+        const response = await axios.post(slackWebhookUrl, {
+            text: message, // The message you want to send
+        });
+
+        console.log('Message sent to Slack: ', response.status);
+    } catch (error) {
+        console.error('Error sending message to Slack: ', error);
+    }
+}
+
+// Call the function to send a message
+sendSlackMessage('Hello, this is a test message from the Slack webhook integration!');


### PR DESCRIPTION
To integrate a Slack webhook in a JavaScript file, you can use the axios package to send HTTP requests to your Slack webhook URL. Here's how to create a basic script that sends a message to a Slack channel using a webhook.

Steps:
Install Axios (if you haven't already):
npm install axios

Explanation:
axios.post(): Sends a POST request to your Slack webhook URL. Payload ({ text: message }): Slack expects a JSON object with a text field that contains the message. Usage:
Replace the slackWebhookUrl with your actual Slack webhook URL. Run the script: node slackWebhook.js
This script will send a message to the Slack channel configured with your webhook.